### PR TITLE
Compact stacki box and fix centos iso URL

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,11 +1,11 @@
 # isos
 CENTOS7_ISO_PATH=artifacts/centos-7.2.1511-everything.iso
-CENTOS7_ISO_URL=https://mirrors.kernel.org/centos/7.2.1511/isos/x86_64/CentOS-7-x86_64-Everything-1511.iso
+CENTOS7_ISO_URL=http://archive.kernel.org/centos-vault/7.2.1511/isos/x86_64/CentOS-7-x86_64-Everything-1511.iso
 STACKI_ISO_PATH=artifacts/stacki-3.2-7.x.x86_64.disk1.iso
 STACKI_ISO_URL=https://stacki.s3.amazonaws.com/public/pallets/3.2/open-source/stacki-3.2-7.x.x86_64.disk1.iso
 # checksums and sigs
 CENTOS7_ISO_GPGKEY=6341AB2753D78A78A7C27BB124C6A8A7F4A80EB5
-CENTOS7_ISO_HASH_SIG_URL=https://mirrors.kernel.org/centos/7.2.1511/isos/x86_64/sha256sum.txt.asc
+CENTOS7_ISO_HASH_SIG_URL=http://archive.kernel.org/centos-vault/7.2.1511/isos/x86_64/sha256sum.txt.asc
 CENTOS7_ISO_HASH_SIG_PATH=artifacts/centos-7.2.1511-everything.sha256sums.txt.asc
 CENTOS7_LOCKFILE=artifacts/centos-7.2.1511-everything.lock
 

--- a/scripts/install-stacki.sh
+++ b/scripts/install-stacki.sh
@@ -26,3 +26,8 @@ sed -i -r "s/^GATEWAY=.*$/GATEWAY=10.0.2.2/" /etc/sysconfig/network
 # clean everything up
 rm /tmp/stacki.iso
 rm /tmp/centos7.iso
+systemctl stop foundation-mariadb
+sh -c 'dd if=/dev/zero of=/boot/zero bs=1024k || :'
+rm -f /boot/zero
+sh -c 'dd if=/dev/zero of=/tmp/zero bs=1024k || :'
+rm -f /tmp/zero


### PR DESCRIPTION
The URL for the CentOS ISO was no longer valid since CentOS 7.3 has been released. Old releases of CentOS are moved to the CentOS Vault. URL updated to reflect this.

The resulting stacki box is pretty large. I was able to reduce its size by 14G by zeroing the free space on disk.